### PR TITLE
Update grape-swagger-entity lib from upstream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,8 @@ Metrics/MethodLength:
   Exclude:
     - spec/**/*
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,19 @@ after_success:
   - bundle exec danger
 
 rvm:
-  - 2.4.2
-  - 2.3.5
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 
 env:
-  - GRAPE_ENTITY=0.5.2
   - GRAPE_ENTITY=0.6.1
+  - GRAPE_ENTITY=0.7.1
 
 matrix:
   fast_finish: true
 
   include:
-    - rvm: 2.2.8
+    - rvm: 2.3.8
       env:
     - rvm: ruby-head
       env:
@@ -31,7 +32,7 @@ matrix:
       env:
 
   allow_failures:
-    - rvm: 2.2.8
+    - rvm: 2.3.8
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 #### Features
 
-* [#38](https://github.com/ruby-grape/grape-swagger-entity/pull/38): Added support for hidden option for documentation - [@vitoravelino](https://github.com/vitoravelino).
+* Your contribution here.
 
 #### Fixes
 
 * Your contribution here.
+
+### 0.3.2 (January 15, 2019)
+
+#### Features
+
+* [#38](https://github.com/ruby-grape/grape-swagger-entity/pull/38): Added support for hidden option for documentation - [@vitoravelino](https://github.com/vitoravelino).
 
 ### 0.3.1 (November 26, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 #### Features
 
-* [#37](https://github.com/ruby-grape/grape-swagger-entity/pull/37): Add support for minItems, maxItems and uniqueItems - [@fotos](https://github.com/fotos).
 * Your contribution here.
 
 #### Fixes
 
 * Your contribution here.
+
+### 0.3.1 (November 26, 2018)
+
+#### Features
+
+* [#37](https://github.com/ruby-grape/grape-swagger-entity/pull/37): Add support for minItems, maxItems and uniqueItems - [@fotos](https://github.com/fotos).
 
 ### 0.3.0 (August 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#35](https://github.com/ruby-grape/grape-swagger-entity/pull/35): Support for required attributes - [@Bugagazavr](https://github.com/Bugagazavr).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#38](https://github.com/ruby-grape/grape-swagger-entity/pull/38): Added support for hidden option for documentation - [@vitoravelino](https://github.com/vitoravelino).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#37](https://github.com/ruby-grape/grape-swagger-entity/pull/37): Add support for minItems, maxItems and uniqueItems - [@fotos](https://github.com/fotos).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 #### Features
 
-* [#35](https://github.com/ruby-grape/grape-swagger-entity/pull/35): Support for required attributes - [@Bugagazavr](https://github.com/Bugagazavr).
 * Your contribution here.
 
 #### Fixes
 
 * Your contribution here.
+
+### 0.3.0 (August 22, 2018)
+
+#### Features
+
+* [#35](https://github.com/ruby-grape/grape-swagger-entity/pull/35): Support for required attributes - [@Bugagazavr](https://github.com/Bugagazavr).
 
 ### 0.2.5 (April 26, 2018)
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ group :development, :test do
   gem 'rubocop', '~> 0.48'
 end
 
+gem 'grape-swagger', path: '../grape-swagger'
+
 group :test do
   gem 'grape-entity', ENV.fetch('GRAPE_ENTITY', '0.6.1')
   gem 'ruby-grape-danger', '~> 0.1.1', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.48'
 end
 
-gem 'grape-swagger', git: 'https://github.com/Bugagazavr/grape-swagger.git', branch: 'required'
+gem 'grape-swagger', git: 'https://github.com/ruby-grape/grape-swagger.git'
 
 group :test do
   gem 'grape-entity', ENV.fetch('GRAPE_ENTITY', '0.6.1')

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.48'
 end
 
-gem 'grape-swagger', path: '../grape-swagger'
+gem 'grape-swagger', git: 'https://github.com/Bugagazavr/grape-swagger.git', branch: 'required'
 
 group :test do
   gem 'grape-entity', ENV.fetch('GRAPE_ENTITY', '0.6.1')

--- a/grape-swagger-entity.gemspec
+++ b/grape-swagger-entity.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.6'
   s.add_runtime_dependency 'grape-entity', '>= 0.5.0'
-  #s.add_runtime_dependency 'grape-swagger', '>= 0.20.4'
+  s.add_runtime_dependency 'grape-swagger', '>= 0.20.4'
 end

--- a/grape-swagger-entity.gemspec
+++ b/grape-swagger-entity.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.6'
   s.add_runtime_dependency 'grape-entity', '>= 0.5.0'
-  s.add_runtime_dependency 'grape-swagger', '>= 0.20.4'
+  s.add_runtime_dependency 'grape-swagger', '>= 0.31.0'
 end

--- a/grape-swagger-entity.gemspec
+++ b/grape-swagger-entity.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.6'
   s.add_runtime_dependency 'grape-entity', '>= 0.5.0'
-  s.add_runtime_dependency 'grape-swagger', '>= 0.20.4'
+  #s.add_runtime_dependency 'grape-swagger', '>= 0.20.4'
 end

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -13,7 +13,17 @@ module GrapeSwagger
 
         if entity_model
           name = endpoint.nil? ? entity_model.to_s.demodulize : endpoint.send(:expose_params_from_model, entity_model)
-          return entity_model_type(name, entity_options)
+
+          entity_model_type = entity_model_type(name, entity_options)
+          return entity_model_type unless documentation
+
+          if documentation[:is_array]
+            entity_model_type[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+            entity_model_type[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+            entity_model_type[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+          end
+
+          entity_model_type
         else
           param = data_type_from(entity_options)
           return param unless documentation

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -17,11 +17,7 @@ module GrapeSwagger
           entity_model_type = entity_model_type(name, entity_options)
           return entity_model_type unless documentation
 
-          if documentation[:is_array]
-            entity_model_type[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
-            entity_model_type[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
-            entity_model_type[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
-          end
+          add_array_documentation(entity_model_type, documentation) if documentation[:is_array]
 
           entity_model_type
         else
@@ -37,9 +33,7 @@ module GrapeSwagger
 
           if documentation[:is_array]
             param = { type: :array, items: param }
-            param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
-            param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
-            param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+            add_array_documentation(param, documentation)
           end
 
           param
@@ -113,6 +107,12 @@ module GrapeSwagger
         return unless example
 
         attribute[:example] = example.is_a?(Proc) ? example.call : example
+      end
+
+      def add_array_documentation(param, documentation)
+        param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+        param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+        param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
       end
     end
   end

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -35,7 +35,13 @@ module GrapeSwagger
             param[:enum] = values if values.is_a?(Array)
           end
 
-          param = { type: :array, items: param } if documentation[:is_array]
+          if documentation[:is_array]
+            param = { type: :array, items: param }
+            param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+            param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+            param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+          end
+
           param
         end
       end

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -42,6 +42,7 @@ module GrapeSwagger
 
       def could_it_be_a_model?(value)
         return false if value.nil?
+
         direct_model_type?(value[:type]) || ambiguous_model_type?(value[:type])
       end
 
@@ -94,6 +95,7 @@ module GrapeSwagger
 
       def add_attribute_example(attribute, example)
         return unless example
+
         attribute[:example] = example.is_a?(Proc) ? example.call : example
       end
     end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -45,7 +45,8 @@ module GrapeSwagger
                                       attribute_parser.call(entity_options)
                                     end
 
-        next unless documentation
+          next unless documentation
+
           memo[final_entity_name][:readOnly] = documentation[:read_only].to_s == 'true' if documentation[:read_only]
           memo[final_entity_name][:description] = documentation[:desc] if documentation[:desc]
           memo[final_entity_name].merge!(documentation[:documentation]) if documentation[:documentation]
@@ -93,6 +94,7 @@ module GrapeSwagger
 
       def with_required(hash, required)
         return hash if required.empty?
+
         hash[:required] = required
         hash
       end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -34,7 +34,10 @@ module GrapeSwagger
         return unless params
 
         parsed = params.each_with_object({}) do |(entity_name, entity_options), memo|
-          next if entity_options.fetch(:documentation, {}).fetch(:in, nil).to_s == 'header'
+          documentation_options = entity_options.fetch(:documentation, {})
+          in_option = documentation_options.fetch(:in, nil).to_s
+          hidden_option = documentation_options.fetch(:hidden, nil)
+          next if in_option == 'header' || hidden_option == true
 
           final_entity_name = entity_options.fetch(:as, entity_name)
           documentation = entity_options[:documentation]

--- a/lib/grape-swagger/entity/version.rb
+++ b/lib/grape-swagger/entity/version.rb
@@ -1,5 +1,5 @@
 module GrapeSwagger
   module Entity
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end

--- a/lib/grape-swagger/entity/version.rb
+++ b/lib/grape-swagger/entity/version.rb
@@ -1,5 +1,5 @@
 module GrapeSwagger
   module Entity
-    VERSION = '0.3.1'.freeze
+    VERSION = '0.3.2'.freeze
   end
 end

--- a/lib/grape-swagger/entity/version.rb
+++ b/lib/grape-swagger/entity/version.rb
@@ -1,5 +1,5 @@
 module GrapeSwagger
   module Entity
-    VERSION = '0.2.5'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -59,7 +59,8 @@ describe 'responseModel' do
             'relation' => { '$ref' => '#/definitions/Relation', 'description' => 'A related model.' },
             'code' => { 'type' => 'string', 'description' => 'Error code' },
             'message' => { 'type' => 'string', 'description' => 'Error message' },
-            'attr' => { 'type' => 'string', 'description' => 'Attribute' } }
+            'attr' => { 'type' => 'string', 'description' => 'Attribute' } },
+      'required' => ['attr']
     )
 
     expect(subject['definitions'].keys).to include 'Kind'
@@ -255,6 +256,7 @@ describe 'building definitions from given entities' do
         'message' => { 'type' => 'string', 'description' => 'Error message' },
         'attr' => { 'type' => 'string', 'description' => 'Attribute' }
       },
+      'required' => %w[attr],
       'description' => 'This returns something'
     )
   end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -15,6 +15,24 @@ describe GrapeSwagger::Entity::AttributeParser do
 
         it { is_expected.to include('type' => 'array') }
         it { is_expected.to include('items' => { '$ref' => '#/definitions/Tag' }) }
+
+        context 'when it contains min_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, min_items: 1 } } }
+
+          it { is_expected.to include(minItems: 1) }
+        end
+
+        context 'when it contains max_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, max_items: 1 } } }
+
+          it { is_expected.to include(maxItems: 1) }
+        end
+
+        context 'when it contains unique_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, unique_items: true } } }
+
+          it { is_expected.to include(uniqueItems: true) }
+        end
       end
 
       context 'when it is not exposed as an array' do

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require_relative '../../../spec/support/shared_contexts/this_api'
+
+describe GrapeSwagger::Entity::AttributeParser do
+  include_context 'this api'
+
+  describe '#call' do
+    let(:endpoint) {}
+
+    subject { described_class.new(endpoint).call(entity_options) }
+
+    context 'when the entity is a model' do
+      context 'when it is exposed as an array' do
+        let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true } } }
+
+        it { is_expected.to include('type' => 'array') }
+        it { is_expected.to include('items' => { '$ref' => '#/definitions/Tag' }) }
+      end
+
+      context 'when it is not exposed as an array' do
+        let(:entity_options) { { using: ThisApi::Entities::Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' } } }
+
+        it { is_expected.to_not include('type') }
+        it { is_expected.to include('$ref' => '#/definitions/Kind') }
+      end
+    end
+
+    context 'when the entity is not a model' do
+      context 'when it is exposed as an array' do
+        let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true } } }
+
+        it { is_expected.to include(type: :array) }
+        it { is_expected.to include(items: { type: 'string' }) }
+      end
+
+      context 'when it is not exposed as an array' do
+        let(:entity_options) { { documentation: { type: 'string', desc: 'Content of something.' } } }
+
+        it { is_expected.to include(type: 'string') }
+        it { is_expected.to_not include('$ref') }
+      end
+    end
+  end
+end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -49,6 +49,24 @@ describe GrapeSwagger::Entity::AttributeParser do
 
         it { is_expected.to include(type: :array) }
         it { is_expected.to include(items: { type: 'string' }) }
+
+        context 'when it contains min_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, min_items: 1 } } }
+
+          it { is_expected.to include(minItems: 1) }
+        end
+
+        context 'when it contains max_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, max_items: 1 } } }
+
+          it { is_expected.to include(maxItems: 1) }
+        end
+
+        context 'when it contains unique_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, unique_items: true } } }
+
+          it { is_expected.to include(uniqueItems: true) }
+        end
       end
 
       context 'when it is not exposed as an array' do

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -24,6 +24,10 @@ describe GrapeSwagger::Entity::Parser do
         expect(properties[:message][:type]).to eq('string')
         expect(properties[:attr][:type]).to eq('string')
       end
+
+      it 'hides hidden attributes' do
+        expect(properties).to_not include(:hidden_attr)
+      end
     end
   end
 end

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -5,22 +5,24 @@ describe GrapeSwagger::Entity::Parser do
   include_context 'this api'
 
   describe '#call' do
-    subject(:parsed_entity) { described_class.new(ThisApi::Entities::Something, endpoint).call }
+    let(:parsed_entity) { described_class.new(ThisApi::Entities::Something, endpoint).call }
+    let(:properties) { parsed_entity.first }
+    let(:required) { parsed_entity.last }
 
     context 'when no endpoint is passed' do
       let(:endpoint) { nil }
 
       it 'parses the model with the correct :using definition' do
-        expect(parsed_entity[:kind]['$ref']).to eq('#/definitions/Kind')
-        expect(parsed_entity[:kind2]['$ref']).to eq('#/definitions/Kind')
-        expect(parsed_entity[:kind3]['$ref']).to eq('#/definitions/Kind')
+        expect(properties[:kind]['$ref']).to eq('#/definitions/Kind')
+        expect(properties[:kind2]['$ref']).to eq('#/definitions/Kind')
+        expect(properties[:kind3]['$ref']).to eq('#/definitions/Kind')
       end
 
       it 'merges attributes that have merge: true defined' do
-        expect(parsed_entity[:merged_attribute]).to be_nil
-        expect(parsed_entity[:code][:type]).to eq('string')
-        expect(parsed_entity[:message][:type]).to eq('string')
-        expect(parsed_entity[:attr][:type]).to eq('string')
+        expect(properties[:merged_attribute]).to be_nil
+        expect(properties[:code][:type]).to eq('string')
+        expect(properties[:message][:type]).to eq('string')
+        expect(properties[:attr][:type]).to eq('string')
       end
     end
   end

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -18,7 +18,7 @@ shared_context 'this api' do
         end
 
         class Nested < Grape::Entity
-          expose :attr, documentation: { type: 'string', desc: 'Attribute' }
+          expose :attr, documentation: { required: true, type: 'string', desc: 'Attribute' }
           expose :nested_attrs, merge: true, using: ThisApi::Entities::Error
         end
 

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -25,6 +25,7 @@ shared_context 'this api' do
         class Something < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
           expose :colors, documentation: { type: 'string', desc: 'Colors', is_array: true }
+          expose :hidden_attr, documentation: { type: 'string', desc: 'Hidden', hidden: true }
           expose :kind, using: Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' }
           expose :kind2, using: Kind, documentation: { desc: 'Secondary kind.' }
           expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }


### PR DESCRIPTION
Related Issue(s) or Task(s)

Update grape-swagger-entity library from upstream

Why?

Warning messages while running the tests
DEPRECATED: You are using old grape-swagger-entity version, which doesn't provide required attributes. To solve this problem, please update grape-swagger-entity

How?

rebase from upstream

Risks

impacts api docs

Requested Reviewers

@gregfletch @kirksmithzt @yinglizt 
